### PR TITLE
#10 Implemented (Boom for 404 error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omdb-bot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Finds infos from IMDB via OMDB API.",
   "main": "./src/server.js",
   "scripts": {
@@ -53,6 +53,7 @@
     "Kreig Zimmerman (https://github.com/kreig303)"
   ],
   "dependencies": {
+    "@hapi/boom": "^7.4.2",
     "@hapi/joi": "^15.0.0",
     "@hapi/wreck": "^15.0.0",
     "hapi": "^18.1.0"

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const Hapi = require('hapi')
+const Boom = require('@hapi/boom')
+
 const server = Hapi.server({
   port: 3030,
   host: 'localhost'
@@ -20,7 +22,7 @@ const init = async () => {
     method: '*',
     path: '/{any*}',
     handler: function (request, h) {
-      return '404'
+      return Boom.notFound('That path doesn\'t exist!')
     }
   })
   await addAPIs()

--- a/src/server.js
+++ b/src/server.js
@@ -21,7 +21,7 @@ const init = async () => {
   server.route({
     method: '*',
     path: '/{any*}',
-    handler: function (request, h) {
+    handler: (request, h) => {
       return Boom.notFound('That path doesn\'t exist!')
     }
   })


### PR DESCRIPTION
* `@hapi/boom` added.
* `404` error handler modified to utilize it.
* changed handlers syntax to use es6 arrow